### PR TITLE
Added realtime_rools dependecy

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>realtime_tools</exec_depend>
   <!--<exec_depend>ros2_control_demo_description</exec_depend> -->
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>


### PR DESCRIPTION
Added dependency `realtime_tools` to avoid the following error:

![image](https://github.com/user-attachments/assets/678899c9-e0e4-4224-aad4-92476cd443d5)
