### PR TITLE
Fixed cmd_vel and odom remappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,5 @@ To activate, change this code section in hoverboard_driver.cpp
 # TODO
 - add serial port as argument to launch file
 - add working PID controller
-- mapping /cmd_vel to hoverboard_driver_base/cmd_vel_unstamped not working now
 - split hoverboard_driver.cpp classes into separate files
 - clean up name mixup between hoverboard and diffbot to be more clear

--- a/bringup/launch/diffbot.launch.py
+++ b/bringup/launch/diffbot.launch.py
@@ -64,15 +64,16 @@ def generate_launch_description():
         executable="ros2_control_node",
         parameters=[robot_description, robot_controllers],
         output="both",
+        remappings=[
+            ("/hoverboard_base_controller/cmd_vel_unstamped", "/cmd_vel"),
+            ("/hoverboard_base_controller/odom", "/odom"),
+        ],
     )
     robot_state_pub_node = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
         parameters=[robot_description],
-        remappings=[
-            ("/hoverboard_base_controller/cmd_vel_unstamped", "/cmd_vel"),
-        ],
     )
     #rviz_node = Node(
     #    package="rviz2",


### PR DESCRIPTION
Remappings topics on `control_node` instead of `robot_state_pub_node`.