### PR TITLE
Better odom estimates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Find the documentation in [doc/userdoc.rst](doc/userdoc.rst) or on [control.ros.
 
 # Hints
 Connect Hoverboard PCB (USART3, GND, TX, RX, no VCC!!) to USB-TTL converter (or UART interface of your SBC).
-Set the serial port according to your setup in hoverboard_driver.ros2_control.xacro file
+Set the serial port according to your setup in hoverboard_driver.ros2_control.xacro file.
+
+Can also be used with [gen2.x firmware](https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x-GD32) for splitboard hoverboards (with RemoteROS2 configured in [config.h](https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x-GD32/blob/main/HoverBoardGigaDevice/Inc/config.h)).
 
 # Launch
 ```

--- a/bringup/config/hoverboard_controllers.yaml
+++ b/bringup/config/hoverboard_controllers.yaml
@@ -27,7 +27,8 @@ hoverboard_base_controller:
     pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
     twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 
-    open_loop: true
+    open_loop: false
+    position_feedback: true
     enable_odom_tf: true
 
     cmd_vel_timeout: 0.5


### PR DESCRIPTION
Changed open_loop to false (i.e. closed loop odom estimates that use feedback from hoverboard) and position_feedback to true (i.e. use position from hoverboard feedback in odom estimate).

Tested on ROS2 iron and jazzy.