### PR TITLE
Support for IMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ To activate, change this code section in hoverboard_driver.cpp
            hw_commands_[left_wheel] / 0.10472,
            hw_commands_[right_wheel] / 0.10472
      };
-     ```
+```
+
+# IMU
+
+The [gen2.x firmware](https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x-GD32) supports sending IMU data (gyroscope and accelerometer) from hoverboard.
+The IMU data can be used in a Extended Kalman filter (EKF) from [robot_localization](https://docs.ros.org/en/noetic/api/robot_localization/html/index.html) package for improved localization. The EKF can be used for [smoothing odometry](https://docs.nav2.org/setup_guides/odom/setup_robot_localization.html) between wheel encoder updates by fusing IMU data with wheel encoders and compensate for eg. wheel slippage.
+IMU can be enabled using parameter imu_enabled in hoverboard_driver.ros2_control.xacro (and the hoverboard firmware also of course needs to be configured to send IMU data).
+The gen2.x firmware sends IMU data every 10 ms, so update_rate in hoverboard_controllers.yaml should be updated to 100 Hz. This will cause read() to be called every 10 ms (otherwise with 10 Hz the timestamps in the IMU messages will be the same and there will be no IMU messages between the wheel encoder feedback messages, which defeats the purpose of the IMU messages). It will also cause write() to be called every 10ms, but there is a write_period constant that makes sure that speed commands are only sent every 100ms to hoverboard.
+The parameter publish_rate in hoverboard_controllers.yaml can be used to further tune the wheel odometry update rate (publish_rate can also be added to joint_state_broadcaster) to limit load on network or cpu with update_rate 100 Hz if needed.
+The default values of the covariance matrices are calculated from MPU6500 datasheet. They can be configured with the linear_acceleration_covariance_diagonal and angular_velocity_covariance_diagonal parameters in hoverboard_driver.ros2_control.xacro. If the EKF becomes twitchy, increase these values by a factor of 10 to account for eg. hoverboard vibrations.
 
 # TODO
 - add serial port as argument to launch file

--- a/description/ros2_control/hoverboard_driver.ros2_control.xacro
+++ b/description/ros2_control/hoverboard_driver.ros2_control.xacro
@@ -9,6 +9,11 @@
         <param name="wheel_radius">0.0825</param>
         <param name="max_velocity">1.0</param>
         <param name="device">/dev/serial/by-id/usb-FTDI_Quad_RS232-HS-if01-port0</param>
+        <!--<param name="imu_enabled">true</param>-->
+        <!--<param name="imu0_frame_id">imu0_link</param>-->
+        <!--<param name="imu1_frame_id">imu1_link</param>-->
+        <!--<param name="linear_acceleration_covariance_diagonal">0.00025 0.00025 0.00025</param>-->
+        <!--<param name="angular_velocity_covariance_diagonal">1.28e-6 1.28e-6 1.28e-6</param>-->
       </hardware>
       <joint name="${prefix}left_wheel_joint">
         <command_interface name="velocity"/>

--- a/hardware/hoverboard_driver.cpp
+++ b/hardware/hoverboard_driver.cpp
@@ -45,6 +45,8 @@ namespace hoverboard_driver
     curr_pub[left_wheel] = this->create_publisher<std_msgs::msg::Float64>("hoverboard/left_wheel/dc_current", 3);
     curr_pub[right_wheel] = this->create_publisher<std_msgs::msg::Float64>("hoverboard/right_wheel/dc_current", 3);
     connected_pub = this->create_publisher<std_msgs::msg::Bool>("hoverboard/connected", 3);
+    imu_pub[0] = this->create_publisher<sensor_msgs::msg::Imu>("hoverboard/imu0/data", 3);
+    imu_pub[1] = this->create_publisher<sensor_msgs::msg::Imu>("hoverboard/imu1/data", 3);
 
     declare_parameter("f", 10.2);
     declare_parameter("p", 1.0);
@@ -113,6 +115,52 @@ namespace hoverboard_driver
     std_msgs::msg::Bool f;
     f.data = message;
     connected_pub->publish(f);
+  }
+
+  void hoverboard_driver_node::publish_imu(const SerialImu& message, const rclcpp::Time &time)
+  {
+    if (!imu_enabled_) {
+      return; // IMU publishing is disabled
+    }
+    sensor_msgs::msg::Imu imu_msg;
+    imu_msg.header.stamp = time;
+    if (message.imuId == 0) {
+      imu_msg.header.frame_id = imu0_frame_id_;
+    } else if (message.imuId == 1) {
+      imu_msg.header.frame_id = imu1_frame_id_;
+    } else {
+      RCLCPP_WARN(get_logger(), "Received IMU message with invalid imuId: %d", message.imuId);
+      return;
+    }
+
+    // Convert raw IMU data to SI units
+    double a_scale = 9.80665 / 16384.0; // assuming +/-2g range
+    imu_msg.linear_acceleration.x = (double)message.accelX * a_scale;
+    imu_msg.linear_acceleration.y = (double)message.accelY * a_scale;
+    imu_msg.linear_acceleration.z = (double)message.accelZ * a_scale;
+
+    double g_scale = (M_PI / 180.0) / 131.0; // assuming +/-250 deg/s range
+    imu_msg.angular_velocity.x = (double)message.gyroX * g_scale;
+    imu_msg.angular_velocity.y = (double)message.gyroY * g_scale;
+    imu_msg.angular_velocity.z = (double)message.gyroZ * g_scale;
+
+    // Use configured covariance diagonals
+    imu_msg.linear_acceleration_covariance = {
+        linear_acceleration_covariance_diagonal_[0], 0.0, 0.0,
+        0.0, linear_acceleration_covariance_diagonal_[1], 0.0,
+        0.0, 0.0, linear_acceleration_covariance_diagonal_[2]
+    };
+
+    imu_msg.angular_velocity_covariance = {
+        angular_velocity_covariance_diagonal_[0], 0.0, 0.0,
+        0.0, angular_velocity_covariance_diagonal_[1], 0.0,
+        0.0, 0.0, angular_velocity_covariance_diagonal_[2]
+    };
+
+    // Orientation Covariance (rad)^2
+    imu_msg.orientation_covariance[0] = -1.0;
+
+    imu_pub[message.imuId]->publish(imu_msg);
   }
 
   rcl_interfaces::msg::SetParametersResult hoverboard_driver_node::parametersCallback(
@@ -233,6 +281,47 @@ namespace hoverboard_driver
     }
 
     hardware_publisher = std::make_shared<hoverboard_driver_node>(); // fire up the publisher node
+    // Set IMU parameters from hardware_info (URDF)
+    if (info_.hardware_parameters.count("imu_enabled"))
+      hardware_publisher->imu_enabled_ = info_.hardware_parameters["imu_enabled"] == "true" || info_.hardware_parameters["imu_enabled"] == "1";
+    if (info_.hardware_parameters.count("imu0_frame_id"))
+      hardware_publisher->imu0_frame_id_ = info_.hardware_parameters["imu0_frame_id"];
+    if (info_.hardware_parameters.count("imu1_frame_id"))
+      hardware_publisher->imu1_frame_id_ = info_.hardware_parameters["imu1_frame_id"];
+
+    // Parse IMU covariance parameters
+    hardware_publisher->linear_acceleration_covariance_diagonal_ = {0.00025, 0.00025, 0.00025};
+    hardware_publisher->angular_velocity_covariance_diagonal_ = {1.28e-6, 1.28e-6, 1.28e-6};
+    if (info_.hardware_parameters.count("linear_acceleration_covariance_diagonal")) {
+      std::istringstream iss(info_.hardware_parameters["linear_acceleration_covariance_diagonal"]);
+      double v[3];
+      if (iss >> v[0] >> v[1] >> v[2]) {
+        hardware_publisher->linear_acceleration_covariance_diagonal_ = {v[0], v[1], v[2]};
+      } else {
+        RCLCPP_WARN(rclcpp::get_logger("hoverboard_driver"), "linear_acceleration_covariance_diagonal is not 3 values. Using defaults.");
+      }
+    }
+    if (info_.hardware_parameters.count("angular_velocity_covariance_diagonal")) {
+      std::istringstream iss(info_.hardware_parameters["angular_velocity_covariance_diagonal"]);
+      double v[3];
+      if (iss >> v[0] >> v[1] >> v[2]) {
+        hardware_publisher->angular_velocity_covariance_diagonal_ = {v[0], v[1], v[2]};
+      } else {
+        RCLCPP_WARN(rclcpp::get_logger("hoverboard_driver"), "angular_velocity_covariance_diagonal is not 3 values. Using defaults.");
+      }
+    }
+
+    // Error handling for IMU frame IDs
+    if (hardware_publisher->imu_enabled_) {
+      if (hardware_publisher->imu0_frame_id_.empty()) {
+        RCLCPP_ERROR(rclcpp::get_logger("hoverboard_driver"), "imu_enabled is true but imu0_frame_id is not set. Using default: 'imu0_link'.");
+        hardware_publisher->imu0_frame_id_ = "imu0_link";
+      }
+      if (hardware_publisher->imu1_frame_id_.empty()) {
+        RCLCPP_WARN(rclcpp::get_logger("hoverboard_driver"), "imu_enabled is true but imu1_frame_id is not set. Using default: 'imu1_link'.");
+        hardware_publisher->imu1_frame_id_ = "imu1_link";
+      }
+    }
 
     return hardware_interface::CallbackReturn::SUCCESS;
   }
@@ -325,7 +414,7 @@ namespace hoverboard_driver
   }
 
   hardware_interface::return_type hoverboard_driver::read(
-      const rclcpp::Time &time, const rclcpp::Duration &period)
+      const rclcpp::Time &time, const rclcpp::Duration & /*period*/)
   {
     // to be able to compare times, we need to set last_read time to a correct time source
     // set the actual time as last_read, when it hasn't been set before (first attempt to read from harware)
@@ -370,7 +459,7 @@ namespace hoverboard_driver
     start_frame = ((uint16_t)(byte) << 8) | (uint8_t)prev_byte;
 
     // Read the start frame
-    if (start_frame == START_FRAME)
+    if ((start_frame == START_FRAME || start_frame == START_FRAME_IMU) && msg_len == 0)
     {
       p = (char *)&msg;
       *p++ = prev_byte;
@@ -384,7 +473,7 @@ namespace hoverboard_driver
       msg_len++;
     }
 
-    if (msg_len == sizeof(SerialFeedback))
+    if (msg_len == sizeof(SerialFeedback) && msg.start == START_FRAME)
     {
       uint16_t checksum = (uint16_t)(msg.start ^
                                      msg.cmd1 ^
@@ -399,7 +488,7 @@ namespace hoverboard_driver
                                      msg.boardTemp ^
                                      msg.cmdLed);
 
-      if (msg.start == START_FRAME && msg.checksum == checksum)
+      if (msg.checksum == checksum)
       {
         hardware_publisher->publish_voltage((double)msg.batVoltage / 100.0);
         hardware_publisher->publish_temp((double)msg.boardTemp / 10.0);
@@ -422,17 +511,55 @@ namespace hoverboard_driver
       }
       msg_len = 0;
     }
+    else if (msg_len == sizeof(SerialImu) && msg.start == START_FRAME_IMU)
+    {
+      SerialImu& imuMsg = *reinterpret_cast<SerialImu*>(&msg);
+
+      uint16_t checksum = (uint16_t)(imuMsg.start ^
+                                     imuMsg.imuId ^
+                                     imuMsg.accelX ^
+                                     imuMsg.accelY ^
+                                     imuMsg.accelZ ^
+                                     imuMsg.gyroX ^
+                                     imuMsg.gyroY ^
+                                     imuMsg.gyroZ);
+
+      if (imuMsg.checksum == checksum)
+      {
+        hardware_publisher->publish_imu(imuMsg, time);
+      }
+      else
+      {
+        RCLCPP_WARN(rclcpp::get_logger("hoverboard_driver"), "Hoverboard IMU message checksum mismatch: %d vs %d", imuMsg.checksum, checksum);
+      }
+      msg_len = 0;
+    }
     prev_byte = byte;
   }
 
   hardware_interface::return_type hoverboard_driver::hoverboard_driver::write(
-      const rclcpp::Time &time, const rclcpp::Duration &period)
+      const rclcpp::Time & /*time*/, const rclcpp::Duration &period)
   {
     if (port_fd == -1)
     {
       RCLCPP_ERROR(rclcpp::get_logger("hoverboard_driver"), "Attempt to write on closed serial");
       return hardware_interface::return_type::ERROR;
     }
+
+    // Add elapsed time since last write() to last_write
+    last_write += period.seconds();
+
+    if (last_write >= write_period)
+    {
+      // Reset last_write, but keep the remainder to prevent drift
+      last_write -= write_period;
+    }
+    else
+    {
+      // Skip this write cycle
+      return hardware_interface::return_type::OK;
+    }
+
     // Inform interested parties about the commands we've got
     hardware_publisher->publish_cmd(left_wheel, hw_commands_[left_wheel]);
     hardware_publisher->publish_cmd(right_wheel, hw_commands_[right_wheel]);
@@ -540,6 +667,14 @@ namespace hoverboard_driver
     hardware_publisher->publish_pos(right_wheel, hw_positions_[right_wheel]);
   }
 
+  // Destructor is called at Ctrl-C after ros2 launch
+  hoverboard_driver::~hoverboard_driver()
+  {
+    if (port_fd != -1) {
+      close(port_fd);
+      port_fd = -1;
+    }
+  }
 } // namespace hoverboard_driver
 
 #include "pluginlib/class_list_macros.hpp"

--- a/hardware/include/hoverboard_driver/hoverboard_driver.hpp
+++ b/hardware/include/hoverboard_driver/hoverboard_driver.hpp
@@ -33,6 +33,7 @@
 #include "hoverboard_driver/protocol.hpp"
 #include "hoverboard_driver/pid.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
@@ -87,6 +88,10 @@ namespace hoverboard_driver
     /// @param message value to publish
     void publish_connected(bool message);
 
+    /// @brief publish IMU data
+    /// @param message value to publish
+    void publish_imu(const SerialImu& message, const rclcpp::Time &time);
+
     /// @brief parameter callback method. 
     /// @param parameters 
     /// @return 
@@ -105,6 +110,14 @@ namespace hoverboard_driver
       bool antiwindup;
     } pid_config;
 
+    // IMU configuration
+    std::string imu0_frame_id_;
+    std::string imu1_frame_id_;
+    bool imu_enabled_ = false;
+
+    std::array<double, 3> linear_acceleration_covariance_diagonal_;
+    std::array<double, 3> angular_velocity_covariance_diagonal_;
+
   private:
     // Publishers
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr vel_pub[2];
@@ -114,6 +127,7 @@ namespace hoverboard_driver
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr curr_pub[2];
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr temp_pub;
     rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr connected_pub;
+    rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub[2];
 
         // Parameter Callback handle
     OnSetParametersCallbackHandle::SharedPtr callback_handle_;
@@ -124,6 +138,7 @@ namespace hoverboard_driver
   {
   public:
     RCLCPP_SHARED_PTR_DEFINITIONS(hoverboard_driver);
+    ~hoverboard_driver() override;
 
     hardware_interface::CallbackReturn on_init(
         const hardware_interface::HardwareInfo &info) override;
@@ -178,9 +193,12 @@ namespace hoverboard_driver
     char prev_byte = 0;
     uint16_t start_frame = 0;
     char *p;
-    SerialFeedback msg, prev_msg;
+    SerialFeedback msg;
 
     PID pids[2];
+
+    double last_write = 0.0; // Time since last write() in seconds
+    const double write_period = 0.1; // Period between writes in seconds. 0.1s = 100ms = 10Hz
   };
 
 } // namespace hoverboard_driver

--- a/hardware/include/hoverboard_driver/protocol.hpp
+++ b/hardware/include/hoverboard_driver/protocol.hpp
@@ -6,6 +6,7 @@
 #define _FOC_PROTOCOL_H
 
 #define START_FRAME 0xABCD
+#define START_FRAME_IMU 0xACDC
 
 typedef struct {
    uint16_t start;
@@ -29,5 +30,17 @@ typedef struct {
    uint16_t cmdLed;
    uint16_t checksum;
 } SerialFeedback;
+
+typedef struct {
+   uint16_t start;  // START_FRAME_IMU=0xACDC
+   uint16_t imuId;  // 0=imu0(Master board), 1=imu1(Slave board)
+   int16_t  accelX;
+   int16_t  accelY;
+   int16_t  accelZ;
+   int16_t  gyroX;
+   int16_t  gyroY;
+   int16_t  gyroZ;
+   uint16_t checksum;
+} SerialImu;
 
 #endif


### PR DESCRIPTION
Added support for IMU. Hoverboards have IMUs (gyroscope and accelerometer) that can be used to improve localization. The gen2x firmware have support to send imu messages over the usart (same as the command and feedback messages). Any imu messages received by hoverboard-driver is published on a imu topic and can be used with ekf in robot_localization package. README.md have been updated with more information and links.
This change is optional and backward compatible (if no imu messages are received from hoverboard, nothing happens and it works just like before). The imu feature can also be disabled with parameter imu_enabled (default disabled).
Have been tested with ROS2 iron (and with both hoverboard firmare that sends and dont sends imu messages).